### PR TITLE
fix: bump sasjs/cli version + 'prepare' support windows CMD/Powershell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,38 +5,37 @@
   "packages": {
     "": {
       "name": "@sasjs/core",
-      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "@sasjs/cli": "^2.27.0"
+        "@sasjs/cli": "2.33.3"
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.6.3.tgz",
-      "integrity": "sha512-Mg1AIDd0JDa0/UjvvmrGxjkpYmGEpqmD1dOYmS55EJG5loAENaVKJg9Ht8bU2XFyVaMbFpgB2yqDd0VWPP4eBA==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.8.9.tgz",
+      "integrity": "sha512-8UChcZlqqlmaMMaKOCr2Bc1h+i2KVDY0FINlPXQN5PdAgEMd8dbxI2p9bsiI1yjYjOBO9LuMl7B79/mwYCtyEw==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
-        "@sasjs/utils": "^2.18.0",
+        "@sasjs/utils": "^2.21.0",
         "axios": "^0.21.1",
         "axios-cookiejar-support": "^1.0.1",
         "form-data": "^4.0.0",
         "https": "^1.0.0",
+        "jwt-decode": "^3.1.2",
         "tough-cookie": "^4.0.0",
         "url": "^0.11.0"
       }
     },
     "node_modules/@sasjs/cli": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-2.27.0.tgz",
-      "integrity": "sha512-jdQBNFbqvkidCL2+V6kuGk66YGH9BshHetPIzYSUCJPYrsKdWYRk0+OP+dZZ4qcNk8yLbcwZH+Z6Y1xh9yroFg==",
+      "version": "2.33.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-2.33.3.tgz",
+      "integrity": "sha512-y1uFM5MEE6eoKLrPUJbweDt4njSy9Y3CS5w5/U2xwNbiAyhiPXgkwCHjCQ8Qg+0rQnMvyNEn6qJuJZ3udc6T7w==",
       "dev": true,
       "dependencies": {
-        "@sasjs/adapter": "2.6.3",
-        "@sasjs/core": "2.34.5",
-        "@sasjs/lint": "1.11.1",
-        "@sasjs/utils": "2.21.0",
+        "@sasjs/adapter": "2.8.9",
+        "@sasjs/core": "2.35.3",
+        "@sasjs/lint": "1.11.2",
+        "@sasjs/utils": "2.23.3",
         "@types/url-parse": "1.4.3",
         "btoa": "1.2.1",
         "chalk": "4.1.1",
@@ -61,34 +60,32 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "2.34.5",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.34.5.tgz",
-      "integrity": "sha512-aq84ce9zmyAnkhKlSQ2SGZSQyJ5+EQAaUwktWfPhVdV9B6FJJSrQL3s1K/Dw9IuMczJcZcBlS4HO/w+goQBgyw==",
-      "dev": true,
-      "hasInstallScript": true
+      "version": "2.35.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.3.tgz",
+      "integrity": "sha512-3o5PU6DkihpA+Aibt1lRy4USqJI0VFa+wNsKCD+bUD2DLZICU3JablZQxwAPH70VWJGXAUJtDFj0T/iRo5Devg==",
+      "dev": true
     },
     "node_modules/@sasjs/lint": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.11.1.tgz",
-      "integrity": "sha512-nb0xFwXSDrE1qQLYV8whUoaXX2lh4nN3jbA/dOlLpjmF+8uvpgZo9GHy5vz5cpIhtguxiFd7lOGN/zyrzKO8yg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.11.2.tgz",
+      "integrity": "sha512-zEonhvha9kwrD+hxhG0hEhtfqpXwffH4vRDIr6eDiXkC7S8M3yImpjyFBvX/THJO5+8iuY8TYkOXKl7+nK/wAg==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "^2.19.0"
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.21.0.tgz",
-      "integrity": "sha512-ehRF1VHBiF8FNg2w4VocjBlb+ZkyMasUZOvUn19bsdqpF0otJVYu66gFOJF0rIpykh/vbpLi6dhqYOxgCRAYIw==",
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.23.3.tgz",
+      "integrity": "sha512-tEh4mGG80eUxSLpbPivA0vl4akMdauL+yZrLn1uUM8EyiXPvlcWPkQTeN6oHbyyAH108D9cfEBidTePZh1p5VQ==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "@types/prompts": "^2.0.13",
         "chalk": "^4.1.1",
         "cli-table": "^0.3.6",
         "consola": "^2.15.0",
         "fs-extra": "^10.0.0",
+        "jwt-decode": "^3.1.2",
         "prompts": "^2.4.1",
         "valid-url": "^1.0.9"
       }
@@ -103,24 +100,24 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "15.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
+      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
       "dev": true
     },
     "node_modules/@types/prompts": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.13.tgz",
-      "integrity": "sha512-jwMOIGy49VruR/gYehhJYgpVzB+EVpEE7t7j9m1oTo4HMpOe7KmsyqdBuoxAzA5B4caUgx0cKrWr7wUEqMXJ7Q==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
+      "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
       "dev": true,
       "peer": true
     },
@@ -1334,6 +1331,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -1762,30 +1760,31 @@
   },
   "dependencies": {
     "@sasjs/adapter": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.6.3.tgz",
-      "integrity": "sha512-Mg1AIDd0JDa0/UjvvmrGxjkpYmGEpqmD1dOYmS55EJG5loAENaVKJg9Ht8bU2XFyVaMbFpgB2yqDd0VWPP4eBA==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.8.9.tgz",
+      "integrity": "sha512-8UChcZlqqlmaMMaKOCr2Bc1h+i2KVDY0FINlPXQN5PdAgEMd8dbxI2p9bsiI1yjYjOBO9LuMl7B79/mwYCtyEw==",
       "dev": true,
       "requires": {
-        "@sasjs/utils": "^2.18.0",
+        "@sasjs/utils": "^2.21.0",
         "axios": "^0.21.1",
         "axios-cookiejar-support": "^1.0.1",
         "form-data": "^4.0.0",
         "https": "^1.0.0",
+        "jwt-decode": "^3.1.2",
         "tough-cookie": "^4.0.0",
         "url": "^0.11.0"
       }
     },
     "@sasjs/cli": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-2.27.0.tgz",
-      "integrity": "sha512-jdQBNFbqvkidCL2+V6kuGk66YGH9BshHetPIzYSUCJPYrsKdWYRk0+OP+dZZ4qcNk8yLbcwZH+Z6Y1xh9yroFg==",
+      "version": "2.33.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-2.33.3.tgz",
+      "integrity": "sha512-y1uFM5MEE6eoKLrPUJbweDt4njSy9Y3CS5w5/U2xwNbiAyhiPXgkwCHjCQ8Qg+0rQnMvyNEn6qJuJZ3udc6T7w==",
       "dev": true,
       "requires": {
-        "@sasjs/adapter": "2.6.3",
-        "@sasjs/core": "2.34.5",
-        "@sasjs/lint": "1.11.1",
-        "@sasjs/utils": "2.21.0",
+        "@sasjs/adapter": "2.8.9",
+        "@sasjs/core": "2.35.3",
+        "@sasjs/lint": "1.11.2",
+        "@sasjs/utils": "2.23.3",
         "@types/url-parse": "1.4.3",
         "btoa": "1.2.1",
         "chalk": "4.1.1",
@@ -1807,24 +1806,24 @@
       }
     },
     "@sasjs/core": {
-      "version": "2.34.5",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.34.5.tgz",
-      "integrity": "sha512-aq84ce9zmyAnkhKlSQ2SGZSQyJ5+EQAaUwktWfPhVdV9B6FJJSrQL3s1K/Dw9IuMczJcZcBlS4HO/w+goQBgyw==",
+      "version": "2.35.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.3.tgz",
+      "integrity": "sha512-3o5PU6DkihpA+Aibt1lRy4USqJI0VFa+wNsKCD+bUD2DLZICU3JablZQxwAPH70VWJGXAUJtDFj0T/iRo5Devg==",
       "dev": true
     },
     "@sasjs/lint": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.11.1.tgz",
-      "integrity": "sha512-nb0xFwXSDrE1qQLYV8whUoaXX2lh4nN3jbA/dOlLpjmF+8uvpgZo9GHy5vz5cpIhtguxiFd7lOGN/zyrzKO8yg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.11.2.tgz",
+      "integrity": "sha512-zEonhvha9kwrD+hxhG0hEhtfqpXwffH4vRDIr6eDiXkC7S8M3yImpjyFBvX/THJO5+8iuY8TYkOXKl7+nK/wAg==",
       "dev": true,
       "requires": {
         "@sasjs/utils": "^2.19.0"
       }
     },
     "@sasjs/utils": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.21.0.tgz",
-      "integrity": "sha512-ehRF1VHBiF8FNg2w4VocjBlb+ZkyMasUZOvUn19bsdqpF0otJVYu66gFOJF0rIpykh/vbpLi6dhqYOxgCRAYIw==",
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.23.3.tgz",
+      "integrity": "sha512-tEh4mGG80eUxSLpbPivA0vl4akMdauL+yZrLn1uUM8EyiXPvlcWPkQTeN6oHbyyAH108D9cfEBidTePZh1p5VQ==",
       "dev": true,
       "requires": {
         "@types/prompts": "^2.0.13",
@@ -1832,6 +1831,7 @@
         "cli-table": "^0.3.6",
         "consola": "^2.15.0",
         "fs-extra": "^10.0.0",
+        "jwt-decode": "^3.1.2",
         "prompts": "^2.4.1",
         "valid-url": "^1.0.9"
       }
@@ -1843,24 +1843,24 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
+      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
       "dev": true
     },
     "@types/prompts": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.13.tgz",
-      "integrity": "sha512-jwMOIGy49VruR/gYehhJYgpVzB+EVpEE7t7j9m1oTo4HMpOe7KmsyqdBuoxAzA5B4caUgx0cKrWr7wUEqMXJ7Q==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
+      "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
       "dev": true,
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "docs": "sasjs doc && ./sasjs/utils/build.sh",
     "test": "sasjs test -t viya",
     "lint": "sasjs lint",
-    "prepare": "[ -d .git ] && git config core.hooksPath ./.git-hooks || true"
+    "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
   },
   "devDependencies": {
-    "@sasjs/cli": "2.27.0"
+    "@sasjs/cli": "2.33.3"
   }
 }


### PR DESCRIPTION
Issue: 

Old CLI has invalid command to support windows CMD/Powershell
![image](https://user-images.githubusercontent.com/8914650/125142450-355f0980-e131-11eb-902d-b85ac78bf009.png)

`prepare` in `package.json` has invalid syntax to support windows CMD/Powershell
![image](https://user-images.githubusercontent.com/8914650/125142549-748d5a80-e131-11eb-9f10-1c3edd77eb2a.png)

Implementation: 
- Bumped latest `sasjs/cli`
- Change `prepare` command

![image](https://user-images.githubusercontent.com/8914650/125142628-a2729f00-e131-11eb-8c59-63bc10ebb9c2.png)
