### PR TITLE
feat: mp_ds2inserts macro

### DIFF
--- a/base/mp_ds2inserts.sas
+++ b/base/mp_ds2inserts.sas
@@ -1,0 +1,115 @@
+/**
+  @file
+  @brief Export a dataset to SQL insert statements
+  @details Converts dataset values to SQL insert statements for use across
+  multiple database types.
+
+  Usage:
+
+      %mp_ds2inserts(sashelp.class,outref=myref)
+      data test;
+        set sashelp.class;
+        stop;
+      proc sql;
+      %inc myref;
+
+  @param [in] ds The dataset to be exported
+  @param [out] outref= (0) The output fileref.  If it does not exist, it is
+    created. If it does exist, new records are APPENDED.
+  @param [out] outlib= (0) The library (or schema) in which the target table is
+    located.  If not provided, is ignored.
+  @param [out] outds= (0) The output table to load.  If not provided, will
+    default to the table in the &ds parameter.
+
+  <h4> SAS Macros </h4>
+  @li mf_existfileref.sas
+  @li mf_getvarcount.sas
+  @li mf_getvarlist.sas
+  @li mf_getvartype.sas
+
+  @version 9.2
+  @author Allan Bowe (credit mjsq)
+**/
+
+%macro mp_ds2inserts(ds, outref=0,outlib=0,outds=0
+)/*/STORE SOURCE*/;
+
+%if not %sysfunc(exist(&ds)) %then %do;
+  %put %str(WARN)ING:  &ds does not exist;
+  %return;
+%end;
+
+%if %index(&ds,.)=0 %then %let ds=WORK.&ds;
+
+%if &outref=0 %then %do;
+  %put %str(WARN)ING:  Please provide a fileref;
+  %return;
+%end;
+%if %mf_existfileref(&outref)=0 %then %do;
+  filename &outref temp lrecl=66000;
+%end;
+
+%if &outlib=0 %then %let outlib=;
+%else %let outlib=&outlib..;
+
+%if &outds=0 %then %let outds=%scan(&ds,2,.);
+
+%local nobs;
+proc sql noprint;
+select count(*) into: nobs TRIMMED from &ds;
+%if &nobs=0 %then %do;
+  data _null_;
+    file &outref mod;
+    put "/* No rows found in &ds */";
+  run;
+%end;
+
+%local vars;
+%let vars=%mf_getvarcount(&ds);
+%if &vars=0 %then %do;
+  data _null_;
+    file &outref mod;
+    put "/* No columns found in &ds */";
+  run;
+%end;
+
+%local varlist;
+%let varlist=%mf_getvarlist(&ds);
+
+proc format; /* credit yabwon for special null removal */
+  value bart ._ - .z = null
+  other = [best.];
+/* next, export data */
+data _null_;
+  file &outref mod ;
+  if _n_=1 then put "/* &outlib..&outds (&nobs rows, &vars columns) */";
+  set &ds;
+  length _____str $32767;
+  format _numeric_ best.;
+  format _character_ ;
+  %local i comma var vtype;
+  %do i=1 %to %sysfunc(countw(&varlist));
+    %let var=%scan(&varlist,&i);
+    %let vtype=%mf_getvartype(&ds,&var);
+    %if &i=1 %then %do;
+      put "insert into &outlib.&outds set ";
+      put "  &var="@;
+    %end;
+    %else %do;
+      put "  ,&var="@;
+    %end;
+    %if &vtype=N %then %do;
+      /* @todo - deal with nulls in other db flavours */
+      /* from ._ to .z */
+      put &var;
+    %end;
+    %else %do;
+      _____str="'"!!trim(tranwrd(&var,"'","''"))!!"'";
+      put _____str;
+    %end;
+  %end;
+  put ';';
+  if _n_=&nobs then put /;
+run;
+
+%mend mp_ds2inserts;

--- a/base/mp_ds2inserts.sas
+++ b/base/mp_ds2inserts.sas
@@ -6,8 +6,8 @@
 
   Usage:
 
-      %mp_ds2inserts(sashelp.class,outref=myref)
-      data test;
+      %mp_ds2inserts(sashelp.class,outref=myref,outds=class)
+      data class;
         set sashelp.class;
         stop;
       proc sql;

--- a/base/mp_ds2inserts.sas
+++ b/base/mp_ds2inserts.sas
@@ -82,7 +82,7 @@ proc format; /* credit yabwon for special null removal */
 /* next, export data */
 data _null_;
   file &outref mod ;
-  if _n_=1 then put "/* &outlib..&outds (&nobs rows, &vars columns) */";
+  if _n_=1 then put "/* &outlib.&outds (&nobs rows, &vars columns) */";
   set &ds;
   length _____str $32767;
   format _numeric_ best.;

--- a/tests/base/mp_ds2inserts.test.sas
+++ b/tests/base/mp_ds2inserts.test.sas
@@ -1,0 +1,31 @@
+/**
+  @file
+  @brief Testing mp_ds2inserts.sas macro
+
+  <h4> SAS Macros </h4>
+  @li mp_ds2inserts.sas
+  @li mp_assert.sas
+
+**/
+
+/**
+  * test 1 - rebuild an existing dataset
+  * Cars is a great dataset - it contains leading spaces, and formatted numerics
+  */
+
+%mp_ds2inserts(sashelp.cars,outref=testref,outlib=work,outds=test)
+
+data work.test;
+  set sashelp.cars;
+  stop;
+proc sql;
+%inc testref;
+
+proc compare base=sashelp.cars compare=work.test;
+quit;
+
+%mp_assert(
+  iftrue=(&sysinfo=1),
+  desc=sashelp.cars is identical except for ds label,
+  outds=work.test_results
+)


### PR DESCRIPTION
A new macro for creating SQL inserts.  Usage:

```sas
      %mp_ds2inserts(sashelp.class,outref=myref,outds=class)
      data class;
        set sashelp.class;
        stop;
      proc sql;
      %inc myref;
```

Generates (first 3 observations shown):

```
 /* class (19 rows, 5 columns) */
 insert into class set 
   Name='Alfred'
   ,Sex='M'
   ,Age=14
   ,Height=69
   ,Weight=112.5
 ;
 insert into class set 
   Name='Alice'
   ,Sex='F'
   ,Age=13
   ,Height=56.5
   ,Weight=84
 ;
 insert into class set 
   Name='Barbara'
   ,Sex='F'
   ,Age=13
   ,Height=65.3
   ,Weight=98
 ;
```

A corresponding test was provided in mp_ds2inserts.test.sas