### PR TITLE
feat: new mf_getapploc macro

### DIFF
--- a/base/mf_getapploc.sas
+++ b/base/mf_getapploc.sas
@@ -1,0 +1,61 @@
+/**
+  @file
+  @brief Returns the appLoc from the _program variable
+  @details When working with SASjs apps, web services / tests / jobs are always
+  deployed to a root (app) location in the SAS logical folder tree.
+
+  When building apps for use in other environments, you do not necessarily know
+  where the backend services will be deployed.  Therefore a function like this
+  is handy in order to dynamically figure out the appLoc, and enable other
+  services to be connected by a relative reference.
+
+  SASjs apps always have the same immediate substructure (one or more of the
+  following):
+
+  @li /data
+  @li /jobs
+  @li /services
+  @li /tests/jobs
+  @li /tests/services
+  @li /tests/macros
+
+  This function works by testing for the existence of any of the above in the
+  automatic _program variable, and returning the part to the left of it.
+
+  Usage:
+
+      %put %mf_getapploc(&_program)
+
+      %put %mf_getapploc(/some/location/services/admin/myservice);
+      %put %mf_getapploc(/some/location/jobs/extract/somejob/);
+      %put %mf_getapploc(/some/location/tests/jobs/somejob/);
+
+
+  @author Allan Bowe
+**/
+
+%macro mf_getapploc(pgm);
+%if "&pgm"="" %then %do;
+  %put &sysmacroname: No value provided;
+  %return;
+%end;
+%local root;
+
+/**
+  * move up two levels to avoid matches on subfolder or service name
+  */
+%let root=%substr(&pgm,1,%length(&pgm)-%length(%scan(&pgm,-1,/))-1);
+%let root=%substr(&root,1,%length(&root)-%length(%scan(&root,-1,/))-1);
+
+%if %index(&root,/tests/) %then %do;
+  %let root=%substr(&root,1,%index(&root,/tests/)-1);
+%end;
+%else %if %index(&root,/services) %then %do;
+  %let root=%substr(&root,1,%index(&root,/services)-1);
+%end;
+%else %if %index(&root,/jobs) %then %do;
+  %let root=%substr(&root,1,%index(&root,/jobs)-1);
+%end;
+%else %put &sysmacroname: Could not find an app location from &pgm;
+  &root
+%mend mf_getapploc ;

--- a/tests/base/mf_getapploc.test.sas
+++ b/tests/base/mf_getapploc.test.sas
@@ -1,0 +1,41 @@
+/**
+  @file
+  @brief Testing mf_getapploc macro
+
+  <h4> SAS Macros </h4>
+  @li mf_getapploc.sas
+  @li mp_assert.sas
+
+**/
+
+%mp_assert(
+  iftrue=(
+    "%mf_getapploc(/some/loc/tests/services/x/service)"="/some/loc"
+  ),
+  desc=Checking test appLoc matches,
+  outds=work.test_results
+)
+
+%mp_assert(
+  iftrue=(
+    "%mf_getapploc(/some/loc/tests/services/tests/service)"="/some/loc"
+  ),
+  desc=Checking nested services appLoc matches,
+  outds=work.test_results
+)
+
+%mp_assert(
+  iftrue=(
+    "%mf_getapploc(/some/area/services/admin/service)"="/some/area"
+  ),
+  desc=Checking services appLoc matches,
+  outds=work.test_results
+)
+
+%mp_assert(
+  iftrue=(
+    "%mf_getapploc(/some/area/jobs/jobs/job)"="/some/area"
+  ),
+  desc=Checking jobs appLoc matches,
+  outds=work.test_results
+)


### PR DESCRIPTION
Creating a new `mf_getapploc` value to dynamically determine the location of backend tests, jobs and web services for a particular SASjs application

Docs:  https://core.sasjs.io/mf__getapploc_8sas.html

![image](https://user-images.githubusercontent.com/4420615/128239484-7d515155-b600-43b8-955b-053b6a8ad244.png)
