### PR TITLE
fix: adding default lengths to vars in mv_getfoldermembers to cover u…

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -7595,7 +7595,7 @@ alter table &libds modify &var char(&len);
 /* If Viya, create temporary fileref(s) */
 %local i;
 %if %mf_getplatform()=SASVIYA %then %do i=1 %to &_webin_file_count;
-  %let _webin_fileref&i=%mf_getuniquefileref(prefix=0);
+  %let _webin_fileref&i=%mf_getuniquefileref();
   filename &&_webin_fileref&i filesrvc "&&_webin_fileuri&i";
 %end;
 
@@ -15794,6 +15794,7 @@ options noquotelenmax;
   run;
   libname &libref2 JSON fileref=&fname2;
   data &outds;
+    length id $36 name $128 uri $64 type $32 description $256;
     set &libref2..items;
   run;
   filename &fname2 clear;

--- a/base/mp_webin.sas
+++ b/base/mp_webin.sas
@@ -50,7 +50,7 @@
 /* If Viya, create temporary fileref(s) */
 %local i;
 %if %mf_getplatform()=SASVIYA %then %do i=1 %to &_webin_file_count;
-  %let _webin_fileref&i=%mf_getuniquefileref(prefix=0);
+  %let _webin_fileref&i=%mf_getuniquefileref();
   filename &&_webin_fileref&i filesrvc "&&_webin_fileuri&i";
 %end;
 

--- a/viya/mv_getfoldermembers.sas
+++ b/viya/mv_getfoldermembers.sas
@@ -122,6 +122,7 @@ options noquotelenmax;
   run;
   libname &libref2 JSON fileref=&fname2;
   data &outds;
+    length id $36 name $128 uri $64 type $32 description $256;
     set &libref2..items;
   run;
   filename &fname2 clear;


### PR DESCRIPTION
…se case where no members found (and downstream process expects an empty table with those vars.  Also fixing mp_webin to cover a case where native temp filerefs (starting with a #hash) are not supported.