### PR TITLE
fix: refactored mp_getconstraints due to apparent bug in dictionary.table_constraints

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: nvm install --latest-npm && npm i -g @sasjs/cli
+  - init: nvm install --lts && npm i -g @sasjs/cli
 
 image:
   file: .gitpod.dockerfile
@@ -20,6 +20,6 @@ github:
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
     addComment: true
     # add a "Review in Gitpod" button to pull requests (defaults to false)
-    addBadge: true
+    addBadge: false
     # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: prebuilt-in-gitpod

--- a/all.sas
+++ b/all.sas
@@ -4466,8 +4466,11 @@ create table &outds as
   on upcase(a.TABLE_CATALOG)=upcase(b.TABLE_CATALOG)
     and upcase(a.TABLE_NAME)=upcase(b.TABLE_NAME)
     and a.constraint_name=b.constraint_name
-  where upcase(a.TABLE_CATALOG)="&lib"
-    and upcase(b.TABLE_CATALOG)="&lib"
+/**
+  * We cannot apply this clause to the underlying dictionary table.  See:
+  * https://communities.sas.com/t5/SAS-Programming/Unexpected-Where-Clause-behaviour-in-dictionary-TABLE/m-p/771554#M244867
+  */
+  where calculated libref="&lib"
   %if "&ds" ne "" %then %do;
     and upcase(a.TABLE_NAME)="&ds"
     and upcase(b.TABLE_NAME)="&ds"

--- a/base/mp_getconstraints.sas
+++ b/base/mp_getconstraints.sas
@@ -49,8 +49,11 @@ create table &outds as
   on upcase(a.TABLE_CATALOG)=upcase(b.TABLE_CATALOG)
     and upcase(a.TABLE_NAME)=upcase(b.TABLE_NAME)
     and a.constraint_name=b.constraint_name
-  where upcase(a.TABLE_CATALOG)="&lib"
-    and upcase(b.TABLE_CATALOG)="&lib"
+/**
+  * We cannot apply this clause to the underlying dictionary table.  See:
+  * https://communities.sas.com/t5/SAS-Programming/Unexpected-Where-Clause-behaviour-in-dictionary-TABLE/m-p/771554#M244867
+  */
+  where calculated libref="&lib"
   %if "&ds" ne "" %then %do;
     and upcase(a.TABLE_NAME)="&ds"
     and upcase(b.TABLE_NAME)="&ds"

--- a/sasjs/sasjsconfig.json
+++ b/sasjs/sasjsconfig.json
@@ -50,7 +50,10 @@
       "appLoc": "/Shared Data/temp/macrocore",
       "macroFolders": [
         "tests/sas9only"
-      ]
+      ],
+      "deployConfig": {
+        "deployServicePack": true
+      }
     },
     {
       "name": "docsonly",

--- a/tests/crossplatform/mp_getconstraints.test.sas
+++ b/tests/crossplatform/mp_getconstraints.test.sas
@@ -1,0 +1,29 @@
+/**
+  @file
+  @brief Testing mp_getconstraints.sas macro
+
+  <h4> SAS Macros </h4>
+  @li mf_nobs.sas
+  @li mp_getconstraints.sas
+  @li mp_assert.sas
+
+**/
+
+proc sql;
+create table work.example(
+  TX_FROM float format=datetime19.,
+  DD_TYPE char(16),
+  DD_SOURCE char(2048),
+  DD_SHORTDESC char(256),
+  constraint pk primary key(tx_from, dd_type,dd_source),
+  constraint unq unique(tx_from, dd_type),
+  constraint nnn not null(DD_SHORTDESC)
+);
+
+%mp_getconstraints(lib=work,ds=example,outds=work.constraints)
+
+%mp_assert(
+  iftrue=(%mf_nobs(work.constraints)=6),
+  desc=Output table work.constraints created with correct number of records,
+  outds=work.test_results
+)


### PR DESCRIPTION
Also added test: https://core.sasjs.io/mp__getconstraints_8test_8sas_source.html

Ran test manually (on SAS 9) due to Viya server outage.  

Closes #83

<a href="https://gitpod.io/#https://github.com/sasjs/core/pull/84"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

