### PR TITLE
`mp_makedata()` improvements

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -7702,10 +7702,14 @@ lock &libds clear;
   <h4> SAS Macros </h4>
   @li mf_getuniquename.sas
   @li mf_getvarlen.sas
+  @li mf_getvarlist.sas
   @li mf_islibds.sas
   @li mf_nobs.sas
   @li mp_getcols.sas
   @li mp_getpk.sas
+
+  <h4> Related Macros </h4>
+  @li mp_makedata.test.sas
 
   @version 9.2
   @author Allan Bowe
@@ -7738,7 +7742,7 @@ lock &libds clear;
 %mp_getpk(&lib,ds=&ds,outds=&ds1)
 
 proc sql noprint;
-select pk_fields into: pk_fields from &ds1;
+select coalescec(pk_fields,'_all_') into: pk_fields from &ds1;
 
 data &ds2;
   if 0 then set &libds;
@@ -7747,7 +7751,7 @@ data &ds2;
     %if &charvars ^= %then %do i=1 %to %sysfunc(countw(&charvars));
       %let col=%scan(&charvars,&i);
       /* create random value based on observation number and colum length */
-      &col=substr(put(md5(_n_),$hex32.),1,%mf_getvarlen(&libds,&col));
+      &col=repeat(put(md5(cats(_n_)),$hex32.),%mf_getvarlen(&libds,&col)/32);
     %end;
 
     %let numvars=%mf_getvarlist(&libds,typefilter=N);

--- a/base/mp_makedata.sas
+++ b/base/mp_makedata.sas
@@ -33,10 +33,14 @@
   <h4> SAS Macros </h4>
   @li mf_getuniquename.sas
   @li mf_getvarlen.sas
+  @li mf_getvarlist.sas
   @li mf_islibds.sas
   @li mf_nobs.sas
   @li mp_getcols.sas
   @li mp_getpk.sas
+
+  <h4> Related Macros </h4>
+  @li mp_makedata.test.sas
 
   @version 9.2
   @author Allan Bowe
@@ -69,7 +73,7 @@
 %mp_getpk(&lib,ds=&ds,outds=&ds1)
 
 proc sql noprint;
-select pk_fields into: pk_fields from &ds1;
+select coalescec(pk_fields,'_all_') into: pk_fields from &ds1;
 
 data &ds2;
   if 0 then set &libds;
@@ -78,7 +82,7 @@ data &ds2;
     %if &charvars ^= %then %do i=1 %to %sysfunc(countw(&charvars));
       %let col=%scan(&charvars,&i);
       /* create random value based on observation number and colum length */
-      &col=substr(put(md5(_n_),$hex32.),1,%mf_getvarlen(&libds,&col));
+      &col=repeat(put(md5(cats(_n_)),$hex32.),%mf_getvarlen(&libds,&col)/32);
     %end;
 
     %let numvars=%mf_getvarlist(&libds,typefilter=N);

--- a/tests/crossplatform/mp_makedata.test.sas
+++ b/tests/crossplatform/mp_makedata.test.sas
@@ -1,0 +1,59 @@
+/**
+  @file
+  @brief Testing mp_makedata.sas macro
+
+  <h4> SAS Macros </h4>
+  @li mf_nobs.sas
+  @li mp_makedata.sas
+  @li mp_assert.sas
+
+**/
+
+/**
+  * Test 1 - Regular makedata call
+  */
+
+proc sql;
+create table work.example(
+  TX_FROM float format=datetime19.,
+  DD_TYPE char(16),
+  DD_SOURCE char(2048),
+  DD_SHORTDESC char(256),
+  constraint pk primary key(tx_from, dd_type,dd_source),
+  constraint nnn not null(DD_SHORTDESC)
+);
+%mp_makedata(work.example,obs=500)
+
+%mp_assert(
+  iftrue=("%mf_nobs(work.example)"="500"),
+  desc=Check that 500 rows were created,
+  outds=work.test_results
+)
+
+data _null_;
+  set work.example;
+  call symputx('lenvar',length(dd_source));
+  stop;
+run;
+%mp_assert(
+  iftrue=("&lenvar"="2048"),
+  desc=Check that entire length of variable is populated,
+  outds=work.test_results
+)
+
+
+proc sql;
+create table work.example2(
+  TX_FROM float format=datetime19.,
+  DD_TYPE char(16),
+  DD_SOURCE char(2048),
+  DD_SHORTDESC char(256),
+  some_num num
+);
+%mp_makedata(work.example2)
+
+%mp_assert(
+  iftrue=(&syscc=0),
+  desc=Ensure tables without keys still generate,
+  outds=work.test_results
+)


### PR DESCRIPTION
fix: enabling makedata support for charvars > $32 and tables without primary keys.  Also added tests.