### PR TITLE
Writefile

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -249,8 +249,12 @@ https://github.com/yabwon/SAS_PACKAGES/blob/main/packages/baseplus.md#functionex
 
         %put %mf_existvar(work.someds, somevar)
 
-  @param libds (positional) - 2 part dataset or view reference
-  @param var (positional) - variable name
+  @param [in] libds 2 part dataset or view reference
+  @param [in] var variable name
+
+  <h4> Related Macros </h4>
+  @li mf_existvar.test.sas
+
   @version 9.2
   @author Allan Bowe
 **/
@@ -1954,6 +1958,72 @@ Usage:
 %mend mf_wordsInStr1ButNotStr2;
 
 /**
+  @file
+  @brief Creates a text file using pure macro
+  @details Creates a text file of up to 10 lines.  If further lines are
+    desired, feel free to [create an issue](
+    https://github.com/sasjs/core/issues/new), or make a pull request!
+
+    The use of PARMBUFF was considered for this macro, but it would have made
+    things problematic for writing lines containing commas.
+
+    Usage:
+
+        %mf_writefile(&sasjswork/myfile.txt,l1=some content,l2=more content)
+        data _null_;
+          infile "&sasjswork/myfile.txt";
+          input;
+          list;
+        run;
+
+  @param [in] fpath Full path to file to be created or appended to
+  @param [in] mode= (O) Available options are A or O as follows:
+    @li A APPEND mode, writes new records after the current end of the file.
+    @li O OUTPUT mode, writes new records from the beginning of the file.
+  @param [in] l1= First line
+  @param [in] l2= Second line (etc through to l10)
+
+  <h4> Related Macros </h4>
+  @li mf_writefile.test.sas
+
+  @version 9.2
+  @author Allan Bowe
+**/
+/** @cond */
+
+%macro mf_writefile(fpath,mode=O,l1=,l2=,l3=,l4=,l5=,l6=,l7=,l8=,l9=,l10=
+)/*/STORE SOURCE*/;
+%local fref rc fid i total_lines;
+
+/* find number of lines by reference to first non-blank param */
+%do i=10 %to 1 %by -1;
+  %if %str(&&l&i) ne %str() %then %goto continue;
+%end;
+%continue:
+%let total_lines=&i;
+
+%if %sysfunc(filename(fref,&fpath)) ne 0 %then %do;
+  %put &=fref &=fpath;
+  %put %str(ERR)OR: %sysfunc(sysmsg());
+  %return;
+%end;
+
+%let fid=%sysfunc(fopen(&fref,&mode));
+
+%if &fid=0 %then %do;
+  %put %str(ERR)OR: %sysfunc(sysmsg());
+  %return;
+%end;
+
+%do i=1 %to &total_lines;
+  %let rc=%sysfunc(fput(&fid, &&l&i));
+  %let rc=%sysfunc(fwrite(&fid));
+%end;
+%let rc=%sysfunc(fclose(&fid));
+%let rc=%sysfunc(filename(&fref));
+
+%mend mf_writefile;
+/** @endcond *//**
   @file
   @brief abort gracefully according to context
   @details Configures an abort mechanism according to site specific policies or
@@ -7943,6 +8013,7 @@ data &ds2;
     %end;
     output;
   end;
+  stop;
 run;
 proc sort data=&ds2 nodupkey;
   by &pk_fields;

--- a/base/mf_existvar.sas
+++ b/base/mf_existvar.sas
@@ -7,8 +7,12 @@
 
         %put %mf_existvar(work.someds, somevar)
 
-  @param libds (positional) - 2 part dataset or view reference
-  @param var (positional) - variable name
+  @param [in] libds 2 part dataset or view reference
+  @param [in] var variable name
+
+  <h4> Related Macros </h4>
+  @li mf_existvar.test.sas
+
   @version 9.2
   @author Allan Bowe
 **/

--- a/base/mf_writefile.sas
+++ b/base/mf_writefile.sas
@@ -1,0 +1,67 @@
+/**
+  @file
+  @brief Creates a text file using pure macro
+  @details Creates a text file of up to 10 lines.  If further lines are
+    desired, feel free to [create an issue](
+    https://github.com/sasjs/core/issues/new), or make a pull request!
+
+    The use of PARMBUFF was considered for this macro, but it would have made
+    things problematic for writing lines containing commas.
+
+    Usage:
+
+        %mf_writefile(&sasjswork/myfile.txt,l1=some content,l2=more content)
+        data _null_;
+          infile "&sasjswork/myfile.txt";
+          input;
+          list;
+        run;
+
+  @param [in] fpath Full path to file to be created or appended to
+  @param [in] mode= (O) Available options are A or O as follows:
+    @li A APPEND mode, writes new records after the current end of the file.
+    @li O OUTPUT mode, writes new records from the beginning of the file.
+  @param [in] l1= First line
+  @param [in] l2= Second line (etc through to l10)
+
+  <h4> Related Macros </h4>
+  @li mf_writefile.test.sas
+
+  @version 9.2
+  @author Allan Bowe
+**/
+/** @cond */
+
+%macro mf_writefile(fpath,mode=O,l1=,l2=,l3=,l4=,l5=,l6=,l7=,l8=,l9=,l10=
+)/*/STORE SOURCE*/;
+%local fref rc fid i total_lines;
+
+/* find number of lines by reference to first non-blank param */
+%do i=10 %to 1 %by -1;
+  %if %str(&&l&i) ne %str() %then %goto continue;
+%end;
+%continue:
+%let total_lines=&i;
+
+%if %sysfunc(filename(fref,&fpath)) ne 0 %then %do;
+  %put &=fref &=fpath;
+  %put %str(ERR)OR: %sysfunc(sysmsg());
+  %return;
+%end;
+
+%let fid=%sysfunc(fopen(&fref,&mode));
+
+%if &fid=0 %then %do;
+  %put %str(ERR)OR: %sysfunc(sysmsg());
+  %return;
+%end;
+
+%do i=1 %to &total_lines;
+  %let rc=%sysfunc(fput(&fid, &&l&i));
+  %let rc=%sysfunc(fwrite(&fid));
+%end;
+%let rc=%sysfunc(fclose(&fid));
+%let rc=%sysfunc(filename(&fref));
+
+%mend mf_writefile;
+/** @endcond */

--- a/base/mp_makedata.sas
+++ b/base/mp_makedata.sas
@@ -92,6 +92,7 @@ data &ds2;
     %end;
     output;
   end;
+  stop;
 run;
 proc sort data=&ds2 nodupkey;
   by &pk_fields;

--- a/tests/crossplatform/mf_existvar.test.sas
+++ b/tests/crossplatform/mf_existvar.test.sas
@@ -1,0 +1,22 @@
+/**
+  @file
+  @brief Testing mf_existvar macro
+
+  <h4> SAS Macros </h4>
+  @li mf_existvar.sas
+  @li mp_assert.sas
+
+**/
+
+
+%mp_assert(
+  iftrue=(%mf_existvar(sashelp.class,age)=1),
+  desc=Checking existing var exists,
+  outds=work.test_results
+)
+
+%mp_assert(
+  iftrue=(%mf_existvar(sashelp.class,isjustanumber)=0),
+  desc=Checking non existing var does not exist,
+  outds=work.test_results
+)

--- a/tests/crossplatform/mf_writefile.test.sas
+++ b/tests/crossplatform/mf_writefile.test.sas
@@ -1,0 +1,74 @@
+/**
+  @file
+  @brief Testing mf_writefile.sas macro
+
+  <h4> SAS Macros </h4>
+  @li mf_writefile.sas
+  @li mp_assert.sas
+
+**/
+
+%mf_writefile(&sasjswork/myfile.txt,l1=some content,l2=more content)
+data _null_;
+  infile "&sasjswork/myfile.txt";
+  input;
+  if _n_=2 then call symputx('test1',_infile_);
+run;
+
+%mp_assert(
+  iftrue=(&syscc=0),
+  desc=Check code ran without errors,
+  outds=work.test_results
+)
+%mp_assert(
+  iftrue=(&test1=more content),
+  desc=Checking line was created,
+  outds=work.test_results
+)
+
+%mf_writefile(&sasjswork/myfile.txt,l1=some content,l2=different content)
+data _null_;
+  infile "&sasjswork/myfile.txt";
+  input;
+  if _n_=2 then call symputx('test2',_infile_);
+run;
+
+%mp_assert(
+  iftrue=(&syscc=0),
+  desc=Check code ran without errors for test2,
+  outds=work.test_results
+)
+%mp_assert(
+  iftrue=(&test2=different content),
+  desc=Checking second line was overwritten,
+  outds=work.test_results
+)
+
+%global test3 test4;
+%mf_writefile(&sasjswork/myfile.txt
+  ,mode=a
+  ,l1=%str(aah, content)
+  ,l2=append content
+)
+data _null_;
+  infile "&sasjswork/myfile.txt";
+  input;
+  if _n_=2 then call symputx('test3',_infile_);
+  if _n_=4 then call symputx('test4',_infile_);
+run;
+
+%mp_assert(
+  iftrue=(&syscc=0),
+  desc=Check code ran without errors for test2,
+  outds=work.test_results
+)
+%mp_assert(
+  iftrue=(&test3=different content),
+  desc=Checking second line was not overwritten,
+  outds=work.test_results
+)
+%mp_assert(
+  iftrue=(&test4=append content),
+  desc=Checking fourth line was appended,
+  outds=work.test_results
+)


### PR DESCRIPTION

* New `mf_writefile()` macro function for creating text files.  Works on both (a)ppend and (o)utput mode.
* Added `stop` statement in `mp_makedata()` to avoid looping NOTE
* Added a test for `mf_existvar()`
