### PR TITLE
feat: new mp_cntlout.sas macro

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -7131,10 +7131,10 @@ create table &outsummary as
       select &&fmtname&i;
     run;
     data &tempds;
-      length label $256;
+      if 0 then set &outdetail;
       set &tempds;
     run;
-    proc append base=&outdetail data=&tempds;
+    proc append base=&outdetail data=&tempds ;
     run;
   %end;
 %end;

--- a/base/mp_cntlout.sas
+++ b/base/mp_cntlout.sas
@@ -1,0 +1,85 @@
+/**
+  @file mp_cntlout.sas
+  @brief Creates a cntlout dataset in a consistent format
+  @details The dataset produced by proc format in the cntlout option will vary
+  according to its contents.
+
+  When dealing with formats from an ETL perspective (eg in [Data Controller for
+  SAS](https://datacontroller.io)), it is important that the output dataset
+  has a consistent model (and compariable values).
+
+  This macro makes use of mddl_sas_cntlout.sas to provide the consistent model,
+  and will left-align the start and end values when dealing with numeric ranges
+  to enable consistency when checking for differences.
+
+  usage:
+
+      %mp_cntlout(libcat=yourlib.cat,cntlout=work.formatexport)
+
+  @param [in] libcat The library.catalog reference
+  @param [in] fmtlist= (0) provide a space separated list of specific formats to
+    extract
+  @param [in] iftrue= (1=1) A condition under which the macro should be executed
+  @param [out] cntlout= (work.fmtextract) Libds reference for the output dataset
+
+  <h4> SAS Macros </h4>
+  @li mddl_sas_cntlout.sas
+  @li mf_getuniquename.sas
+
+  <h4> Related Macros </h4>
+  @li mf_getvarformat.sas
+  @li mp_getformats.sas
+  @li mp_loadformat.sas
+  @li mp_ds2fmtds.sas
+
+  @version 9.2
+  @author Allan Bowe
+  @cond
+**/
+
+%macro mp_cntlout(
+  iftrue=(1=1)
+  ,libcat=
+  ,cntlout=work.fmtextract
+  ,fmtlist=0
+)/*/STORE SOURCE*/;
+%local ddlds cntlds i;
+
+%if not(%eval(%unquote(&iftrue))) %then %return;
+
+%let ddlds=%mf_getuniquename();
+%let cntlds=%mf_getuniquename();
+
+%mddl_sas_cntlout(libds=&ddlds)
+
+%if %index(&libcat,-)>0 and %scan(&libcat,2,-)=FC %then %do;
+  %let libcat=%scan(&libcat,1,-);
+%end;
+
+proc format lib=&libcat cntlout=&cntlds;
+%if "&fmtlist" ne "0" %then %do;
+  select
+  %do i=1 %to %sysfunc(countw(&fmtlist));
+    %scan(&fmtlist,&i,%str( ))
+  %end;
+  ;
+%end;
+run;
+
+data &cntlout;
+  if 0 then set &ddlds;
+  set &cntlds;
+  if type="N" then do;
+    start=cats(start);
+    end=cats(end);
+  end;
+run;
+proc sort;
+  by fmtname start;
+run;
+
+proc sql;
+drop table &ddlds,&cntlds;
+
+%mend mp_cntlout;
+/** @endcond */

--- a/base/mp_getformats.sas
+++ b/base/mp_getformats.sas
@@ -113,10 +113,10 @@ create table &outsummary as
       select &&fmtname&i;
     run;
     data &tempds;
-      length label $256;
+      if 0 then set &outdetail;
       set &tempds;
     run;
-    proc append base=&outdetail data=&tempds;
+    proc append base=&outdetail data=&tempds ;
     run;
   %end;
 %end;

--- a/base/mp_lockanytable.sas
+++ b/base/mp_lockanytable.sas
@@ -48,7 +48,7 @@ data _null_;
   put name '=' value;
 run;
 
-%mp_abort(iftrue= (&ds=0 and &action ne MAKETABLE)
+%mp_abort(iftrue= ("&ds"="0" and &action ne MAKETABLE)
   ,mac=&sysmacroname
   ,msg=%str(dataset was not provided)
 )

--- a/base/mp_lockfilecheck.sas
+++ b/base/mp_lockfilecheck.sas
@@ -37,7 +37,7 @@ run;
   ,mac=checklock.sas
   ,msg=Aborting with syscc=&syscc on entry.
 )
-%mp_abort(iftrue= (&libds=0)
+%mp_abort(iftrue= ("&libds"="0")
   ,mac=&sysmacroname
   ,msg=%str(libds not provided)
 )
@@ -45,6 +45,12 @@ run;
 %local msg lib ds;
 %let lib=%upcase(%scan(&libds,1,.));
 %let ds=%upcase(%scan(&libds,2,.));
+
+/* in DC, format catalogs are passed with a -FC suffix. No saslock here! */
+%if %scan(&libds,2,-)=FC %then %do;
+  %put &sysmacroname: Format Catalog detected, no lockfile applied to &libds;
+  %return;
+%end;
 
 /* do not proceed if no observations can be processed */
 %let msg=options obs = 0. syserrortext=%superq(syserrortext);

--- a/tests/crossplatform/mp_cntlout.test.sas
+++ b/tests/crossplatform/mp_cntlout.test.sas
@@ -1,0 +1,38 @@
+/**
+  @file
+  @brief Testing mp_cntlout.sas macro
+
+  <h4> SAS Macros </h4>
+  @li mp_cntlout.sas
+  @li mp_assert.sas
+  @li mp_assertscope.sas
+
+**/
+
+libname perm (work);
+data work.loadfmts;
+  length fmtname $32;
+  eexcl='Y';
+  type='N';
+  do i=1 to 100;
+    fmtname=cats('SASJS_',i,'X');
+    do j=1 to 100;
+      start=cats(j);
+      end=cats(j+1);
+      label= cats('Dummy ',start);
+      output;
+    end;
+  end;
+run;
+proc format cntlin=work.loadfmts library=perm.testcat;
+run;
+
+%mp_assertscope(SNAPSHOT)
+%mp_cntlout(libcat=perm.testcat,cntlout=work.cntlout)
+%mp_assertscope(COMPARE)
+
+%mp_assert(
+  iftrue=(%mf_nobs(work.cntlout)=10000),
+  desc=Checking first hash diff,
+  outds=work.test_results
+)

--- a/tests/crossplatform/mp_stackdiffs.test.sas
+++ b/tests/crossplatform/mp_stackdiffs.test.sas
@@ -42,6 +42,7 @@ run;
   ,mdebug=1
 )
 
+
 %mp_assertscope(SNAPSHOT)
 
 /**


### PR DESCRIPTION
`mp_cntlout()` provides a consistent way to export formats from a format catalog (start / end left-aligned for numeric lookups, and lengths set to maximums rather than the format content maximums).

Updates to the rest of the framework to support the `-FC` suffix approach for identifying format catlogs in a libds.