### PR TITLE
fix: ensuring audit table gets loaded in mp_loadformat.

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -8872,6 +8872,9 @@ options ibufsize=&ibufsize;
       ,mdebug=&mdebug
     )
 
+    proc append base=&auditlibds data=&storediffs;
+    run;
+
     %if &locklibds ne 0 %then %do;
       %mp_lockanytable(UNLOCK
         ,lib=%scan(&auditlibds,1,.)

--- a/base/mf_getuser.sas
+++ b/base/mf_getuser.sas
@@ -33,7 +33,8 @@
   %else %if %symexist(&metavar) %then %do;
     %if %length(&&&metavar)=0 %then %let user=&sysuserid;
     /* sometimes SAS will add @domain extension - remove for consistency */
-    %else %let user=%scan(&&&metavar,1,@);
+    /* but be sure to quote in case of usernames with commas */
+    %else %let user=%unquote(%scan(%quote(&&&metavar),1,@));
   %end;
   %else %let user=&sysuserid;
 

--- a/base/mp_loadformat.sas
+++ b/base/mp_loadformat.sas
@@ -272,6 +272,9 @@ options ibufsize=&ibufsize;
       ,mdebug=&mdebug
     )
 
+    proc append base=&auditlibds data=&storediffs;
+    run;
+
     %if &locklibds ne 0 %then %do;
       %mp_lockanytable(UNLOCK
         ,lib=%scan(&auditlibds,1,.)

--- a/base/mp_loadformat.sas
+++ b/base/mp_loadformat.sas
@@ -40,13 +40,13 @@
   @li mp_abort.sas
   @li mp_cntlout.sas
   @li mp_lockanytable.sas
+  @li mp_storediffs.sas
 
   <h4> Related Macros </h4>
   @li mddl_dc_difftable.sas
   @li mddl_dc_locktable.sas
   @li mp_loadformat.test.sas
   @li mp_lockanytable.sas
-  @li mp_storediffs.sas
   @li mp_stackdiffs.sas
 
 

--- a/tests/crossplatform/mp_loadformat.test.sas
+++ b/tests/crossplatform/mp_loadformat.test.sas
@@ -3,6 +3,7 @@
   @brief Testing mp_loadformat.sas macro
 
   <h4> SAS Macros </h4>
+  @li mddl_dc_difftable.sas
   @li mp_loadformat.sas
   @li mp_assert.sas
   @li mp_assertscope.sas
@@ -11,6 +12,8 @@
 
 /* prep format catalog */
 libname perm (work);
+
+%mddl_dc_difftable(libds=perm.audit)
 
 data work.loadfmts;
   length fmtname $32;
@@ -49,7 +52,7 @@ run;
 %mp_loadformat(perm.testcat
   ,work.stagedata
   ,loadtarget=YES
-  ,auditlibds=0
+  ,auditlibds=perm.audit
   ,locklibds=0
   ,delete_col=deleteme
   ,outds_add=add_test1
@@ -71,6 +74,11 @@ run;
 )
 %mp_assert(
   iftrue=(%mf_nobs(mod_test1)=100),
+  desc=Test 1 - mod obs,
+  outds=work.test_results
+)
+%mp_assert(
+  iftrue=(%mf_nobs(perm.audit)=100),
   desc=Test 1 - mod obs,
   outds=work.test_results
 )

--- a/tests/crossplatform/mp_loadformat.test.sas
+++ b/tests/crossplatform/mp_loadformat.test.sas
@@ -78,7 +78,7 @@ run;
   outds=work.test_results
 )
 %mp_assert(
-  iftrue=(%mf_nobs(perm.audit)=100),
-  desc=Test 1 - mod obs,
+  iftrue=(%mf_nobs(perm.audit)>7329),
+  desc=Test 1 - audit table updated,
   outds=work.test_results
 )


### PR DESCRIPTION
Adding test  also.  Closes #190

Also quoting `mf_getuser` in case of commas.  Closes #189 