### PR TITLE
fix: send html as attachment rather than streamed content

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -11587,12 +11587,20 @@ run;
   %end;
 %end;
 %else %if &contentype=HTML %then %do;
-  %if &platform=SASVIYA %then %do;
+  %if (&platform=SASMETA and &streamweb=1) %then %do;
+    data _null_;
+      rc=stpsrv_header('Content-type','text/html');
+      rc=stpsrv_header('Content-disposition',"attachment; filename=&outname");
+    run;
+  %end;
+  %else %if &platform=SASVIYA %then %do;
     filename &outref filesrvc parenturi="&SYS_JES_JOB_URI" name="_webout.json"
-      contenttype="text/html";
+      contenttype="text/html"
+      contentdisp="attachment; filename=&outname";
   %end;
   %else %if &platform=SASJS %then %do;
     %mfs_httpheader(Content-type,text/html)
+    %mfs_httpheader(Content-disposition,%str(attachment; filename=&outname))
   %end;
 %end;
 %else %if &contentype=TEXT %then %do;

--- a/base/mp_streamfile.sas
+++ b/base/mp_streamfile.sas
@@ -105,12 +105,20 @@ run;
   %end;
 %end;
 %else %if &contentype=HTML %then %do;
-  %if &platform=SASVIYA %then %do;
+  %if (&platform=SASMETA and &streamweb=1) %then %do;
+    data _null_;
+      rc=stpsrv_header('Content-type','text/html');
+      rc=stpsrv_header('Content-disposition',"attachment; filename=&outname");
+    run;
+  %end;
+  %else %if &platform=SASVIYA %then %do;
     filename &outref filesrvc parenturi="&SYS_JES_JOB_URI" name="_webout.json"
-      contenttype="text/html";
+      contenttype="text/html"
+      contentdisp="attachment; filename=&outname";
   %end;
   %else %if &platform=SASJS %then %do;
     %mfs_httpheader(Content-type,text/html)
+    %mfs_httpheader(Content-disposition,%str(attachment; filename=&outname))
   %end;
 %end;
 %else %if &contentype=TEXT %then %do;


### PR DESCRIPTION
when `mp_streamfile` is used on all platforms