### PR TITLE
fix: prevent warning from `_label_` variable with different lengths

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -11784,7 +11784,9 @@ run;
 %else %let vlist=%mf_getvarlist(&libds,dlm=%str(,),quote=DOUBLE);
 
 data &ds4;
-  length &inds_keep $41 tgtvar_nm $32;
+  length &inds_keep $41 tgtvar_nm $32 _label_ $256;
+  if _n_=1 then call missing(_label_);
+  drop _label_;
   set &ds2 &ds3 indsname=&inds_auto;
 
   tgtvar_nm=upcase(tgtvar_nm);

--- a/base/mp_storediffs.sas
+++ b/base/mp_storediffs.sas
@@ -154,7 +154,9 @@ run;
 %else %let vlist=%mf_getvarlist(&libds,dlm=%str(,),quote=DOUBLE);
 
 data &ds4;
-  length &inds_keep $41 tgtvar_nm $32;
+  length &inds_keep $41 tgtvar_nm $32 _label_ $256;
+  if _n_=1 then call missing(_label_);
+  drop _label_;
   set &ds2 &ds3 indsname=&inds_auto;
 
   tgtvar_nm=upcase(tgtvar_nm);


### PR DESCRIPTION
Closes #281

## Issue

#281

## Intent

Set static length for `_label_`, to both ensure it exists, and also to avoid length warnings

## Implementation

length statement, drop statement, call missing

## Checks

- [ ] Code is formatted correctly (`sasjs lint`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`sasjs test`).
