### PR TITLE
fix: ensuring mp_hashdirectory will output an empty dataset when the …

### DIFF
--- a/base/mp_dirlist.sas
+++ b/base/mp_dirlist.sas
@@ -101,8 +101,7 @@ data &out_ds(compress=no
     if did=0 then do;
       putlog "NOTE: This directory is empty, or does not exist - &path";
       msg=sysmsg();
-      put msg;
-      put _all_;
+      put (_all_)(=);
       stop;
     end;
     /* attribute is OS-dependent - could be "Directory" or "Directory Name" */

--- a/base/mp_hashdirectory.sas
+++ b/base/mp_hashdirectory.sas
@@ -5,7 +5,7 @@
   create a hash for each directory also.
 
   This makes use of the new `hashing_file()` and `hashing` functions, available
-  since 9.4m6. Interestingly, these can even be used in pure macro, eg:
+  since 9.4m6. Interestingly, those functions can be used in pure macro, eg:
 
       %put %sysfunc(hashing_file(md5,/path/to/file.blob,0));
 
@@ -30,8 +30,9 @@
   @li If a folder contains other folders, start from the bottom of the tree -
     the folder hashes cascade upwards so you know immediately if there is a
     change in a sub/sub directory
-  @li If the folder has no content (empty) then it is ignored. No hash created.
+  @li If a subfolder has no content (empty) then it is ignored. No hash created.
   @li If the file is empty, it is also ignored / no hash created.
+  @li If the target directory (&inloc) is empty, &outds will also be empty
 
   <h4> SAS Macros </h4>
   @li mp_dirlist.sas
@@ -72,7 +73,7 @@
   iftrue=%str(1=1)
 )/*/STORE SOURCE*/;
 
-%local curlevel tempds ;
+%local curlevel tempds maxlevel;
 
 %if not(%eval(%unquote(&iftrue))) %then %return;
 
@@ -108,6 +109,7 @@ proc sort data=&outds ;
   by descending level directory file_path;
 run;
 
+%let maxlevel=0;
 data _null_;
   set &outds;
   call symputx('maxlevel',level,'l');

--- a/sasjs/sasjsconfig.json
+++ b/sasjs/sasjsconfig.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "server",
-      "serverUrl": "https://sas.4gl.io",
+      "serverUrl": "https://sas9.4gl.io",
       "serverType": "SASJS",
       "httpsAgentOptions": {
         "allowInsecureRequests": false

--- a/tests/base/mp_hashdirectory.test.sas
+++ b/tests/base/mp_hashdirectory.test.sas
@@ -131,3 +131,19 @@ data _null_;
   set work.hashes2;
   put file_hash file_path;
 run;
+
+/* check that it works when the target directory is missing */
+
+%mp_hashdirectory(&fpath/doesnotexist,outds=work.hashes3,maxdepth=MAX)
+
+%mp_assert(
+  iftrue=(&syscc=0),
+  desc=No errors when directory is missing,
+  outds=work.test_results
+)
+
+%mp_assert(
+  iftrue=(%mf_nobs(work.hashes3)=0),
+  desc=no records created when directory is missing,
+  outds=work.test_results
+)


### PR DESCRIPTION
…target directory does not exist.  Updated tests and documentation also

## Issue

n/a

## Intent

prevent errors when target loc in `mp_hashdirectory()` is empty.  Output empty dataset instead.

## Implementation

Initialised the counter variable to zero.  Also removed a line in mp_dirlist that implied error status when no error was actually raised (`sysmsg()`).

## Checks

- [ ] Code is formatted correctly (`sasjs lint`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`sasjs test`).
