### PR TITLE
fix: invalid macro variable in mp_lockanytable.sas

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -10451,7 +10451,7 @@ run;
         data _null_;
           putlog 'NOTE-' / 'NOTE-';
           putlog "NOTE- &sysmacroname: table locked, waiting "@;
-          putlog "%sysfunc(sleep(&loop_inc)) seconds.. ";
+          putlog "%sysfunc(sleep(&loop_secs)) seconds.. ";
           putlog "NOTE- (iteration &x of &loops)";
           putlog 'NOTE-' / 'NOTE-';
         run;

--- a/all.sas
+++ b/all.sas
@@ -312,13 +312,17 @@ https://github.com/yabwon/SAS_PACKAGES/blob/main/packages/baseplus.md#functionex
   %local dsid rc;
   %let dsid=%sysfunc(open(&libds,is));
 
-  %if &dsid=0 or %length(&var)=0 %then %do;
+  %if &dsid=0 %then %do;
     %put %sysfunc(sysmsg());
-      0
+    0
+  %end;
+  %else %if %length(&var)=0 %then %do;
+    0
+    %let rc=%sysfunc(close(&dsid));
   %end;
   %else %do;
-      %sysfunc(varnum(&dsid,&var))
-      %let rc=%sysfunc(close(&dsid));
+    %sysfunc(varnum(&dsid,&var))
+    %let rc=%sysfunc(close(&dsid));
   %end;
 
 %mend mf_existvar;

--- a/base/mf_existvar.sas
+++ b/base/mf_existvar.sas
@@ -25,13 +25,17 @@
   %local dsid rc;
   %let dsid=%sysfunc(open(&libds,is));
 
-  %if &dsid=0 or %length(&var)=0 %then %do;
+  %if &dsid=0 %then %do;
     %put %sysfunc(sysmsg());
-      0
+    0
+  %end;
+  %else %if %length(&var)=0 %then %do;
+    0
+    %let rc=%sysfunc(close(&dsid));
   %end;
   %else %do;
-      %sysfunc(varnum(&dsid,&var))
-      %let rc=%sysfunc(close(&dsid));
+    %sysfunc(varnum(&dsid,&var))
+    %let rc=%sysfunc(close(&dsid));
   %end;
 
 %mend mf_existvar;

--- a/base/mp_lockanytable.sas
+++ b/base/mp_lockanytable.sas
@@ -167,7 +167,7 @@ run;
         data _null_;
           putlog 'NOTE-' / 'NOTE-';
           putlog "NOTE- &sysmacroname: table locked, waiting "@;
-          putlog "%sysfunc(sleep(&loop_inc)) seconds.. ";
+          putlog "%sysfunc(sleep(&loop_secs)) seconds.. ";
           putlog "NOTE- (iteration &x of &loops)";
           putlog 'NOTE-' / 'NOTE-';
         run;

--- a/tests/base/mf_existvar.test.sas
+++ b/tests/base/mf_existvar.test.sas
@@ -18,3 +18,23 @@
   iftrue=(%mf_existvar(sashelp.class,isjustanumber)=0),
   desc=Checking non existing var does not exist
 )
+
+data work.lockcheck;
+  a=1;
+  output;
+  stop;
+run;
+
+%mp_assert(
+  iftrue=(%mf_existvar(work.lockcheck,)=0),
+  desc=Checking non-provided var does not exist
+)
+
+proc sql;
+update work.lockcheck set a=2;
+
+%mp_assert(
+  iftrue=(&syscc=0),
+  desc=Checking the lock was released,
+  outds=work.test_results
+)

--- a/tests/base/mp_getcols.test.sas
+++ b/tests/base/mp_getcols.test.sas
@@ -7,23 +7,35 @@
   @li mp_assertcols.sas
   @li mp_assertcolvals.sas
   @li mp_assertdsobs.sas
+  @li mp_assertscope.sas
 
 **/
 
 
-/* valid filter */
-%mp_getcols(sashelp.airline,outds=work.info)
+/* make some data */
+proc sql;
+create table work.src(
+  SOME_DATETIME float format=datetime19.,
+  SOME_CHAR char(16),
+  SOME_NUM num,
+  SOME_TIME num format=time8.,
+  SOME_DATE num format=date9.
+);
 
+/* run macro, checking for scope leakage */
+%mp_assertscope(SNAPSHOT)
+%mp_getcols(work.src,outds=work.info)
+%mp_assertscope(COMPARE)
 
 %mp_assertdsobs(work.info,
-  desc=Has 3 records,
-  test=EQUALS 3,
+  desc=Has 5 records,
+  test=EQUALS 5,
   outds=work.test_results
 )
 
 data work.check;
   length val $10;
-  do val='NUMERIC','DATE','CHARACTER';
+  do val='NUMERIC','DATE','CHARACTER','DATETIME','TIME';
     output;
   end;
 run;


### PR DESCRIPTION
## Issue

n/a

## Intent

Fixing some recently discovered bugs

## Implementation

Updates to:

* mf_existvar.sas
* mp_lockanytable.sas

A test is also included to cover the change in mf_existvar.sas

## Checks

- [x] Code is formatted correctly (`sasjs lint`).
- [x] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`sasjs test`).
