### PR TITLE
fix: ensuring acceptable casing of _omitSessionResults

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -27280,7 +27280,7 @@ data _null_;
   uri=symget('uri');
   if length(uri)<12 then do;
     call symputx('errflg',1);
-    call symputx('errmsg',"URI is invalid (too short) - '&uri'",'l');
+    call symputx('errmsg',"URI is too short - "!!uri,'l');
   end;
   if scan(uri,-1)='state' or scan(uri,1) ne 'jobExecution' then do;
     call symputx('errflg',1);
@@ -27345,7 +27345,7 @@ data _null_;
   uri=symget('loglocation');
   if length(uri)<12 then do;
     call symputx('errflg',1);
-    call symputx('errmsg',"URI is invalid (too short) - '&uri'",'l');
+    call symputx('errmsg',"URI is too short - "!!uri,'l');
   end;
   else if (scan(uri,1,'/') ne 'compute' or scan(uri,2,'/') ne 'sessions')
     and (scan(uri,1,'/') ne 'files' or scan(uri,2,'/') ne 'files')
@@ -28433,6 +28433,8 @@ run;
     %if %mf_existvarList(&inds,FLOW_ID)=0 %then %do;
       retain FLOW_ID 0;
     %end;
+    /* https://github.com/sasjs/adapter/pull/845#issuecomment-2956589644 */
+    retain _omitSessionResults "false";
     set &inds;
     &dbg. putlog (_all_)(=);
   run;

--- a/viya/mv_getjoblog.sas
+++ b/viya/mv_getjoblog.sas
@@ -126,7 +126,7 @@ data _null_;
   uri=symget('uri');
   if length(uri)<12 then do;
     call symputx('errflg',1);
-    call symputx('errmsg',"URI is invalid (too short) - '&uri'",'l');
+    call symputx('errmsg',"URI is too short - "!!uri,'l');
   end;
   if scan(uri,-1)='state' or scan(uri,1) ne 'jobExecution' then do;
     call symputx('errflg',1);
@@ -191,7 +191,7 @@ data _null_;
   uri=symget('loglocation');
   if length(uri)<12 then do;
     call symputx('errflg',1);
-    call symputx('errmsg',"URI is invalid (too short) - '&uri'",'l');
+    call symputx('errmsg',"URI is too short - "!!uri,'l');
   end;
   else if (scan(uri,1,'/') ne 'compute' or scan(uri,2,'/') ne 'sessions')
     and (scan(uri,1,'/') ne 'files' or scan(uri,2,'/') ne 'files')

--- a/viya/mv_jobflow.sas
+++ b/viya/mv_jobflow.sas
@@ -188,6 +188,8 @@
     %if %mf_existvarList(&inds,FLOW_ID)=0 %then %do;
       retain FLOW_ID 0;
     %end;
+    /* https://github.com/sasjs/adapter/pull/845#issuecomment-2956589644 */
+    retain _omitSessionResults "false";
     set &inds;
     &dbg. putlog (_all_)(=);
   run;


### PR DESCRIPTION
More info: https://communities.sas.com/t5/SAS-Viya/Returning-webout-from-JES-API/td-p/966992

## Issue

`mv_jobflow` was not returning logs, nor results

## Implementation

Apply specific casing of `_omitSessionResults`, per discussion in link above

