### PR TITLE
Header formatting fix

### DIFF
--- a/viya/mv_getviyafileextparms.sas
+++ b/viya/mv_getviyafileextparms.sas
@@ -31,7 +31,7 @@
   @li mf_nobs.sas
   @li mp_abort.sas
 
-*/
+**/
 
 %macro mv_getViyaFileExtParms(
   ext,


### PR DESCRIPTION
Header formatting fix

There was one `*` missing and I couldn't build SAS package.
