### PR TITLE
Islib validation

### DIFF
--- a/all.sas
+++ b/all.sas
@@ -14541,7 +14541,7 @@ alter table &libds modify &var char(&len);
 %mend mp_updatevarlength;
 /**
   @file
-  @brief Used to validate variables in a dataset
+  @brief Used to validate values in a data step
   @details Useful when sanitising inputs, to ensure that they arrive with a
   certain pattern.
   Usage:
@@ -14568,6 +14568,7 @@ alter table &libds modify &var char(&len);
   @param [in] incol The column to be validated
   @param [in] rule The rule to apply.  Current rules:
     @li ISINT - checks if the variable is an integer
+    @li ISLIB - checks if the value is a valid libref (NOT whether it exists)
     @li ISNUM - checks if the variable is numeric
     @li LIBDS - matches LIBREF.DATASET format
     @li FORMAT - checks if the provided format is syntactically valid
@@ -14605,6 +14606,19 @@ alter table &libds modify &var char(&len);
   if missing(&tempcol) then &outcol=0;
   else &outcol=1;
   drop &tempcol;
+%end;
+%else %if &rule=ISLIB %then %do;
+  if _n_=1 then do;
+    retain &tempcol;
+    &tempcol=prxparse('/^[_a-z]\w{0,7}$/i');
+    if missing(&tempcol) then do;
+      putlog 'ERR' +(-1) "OR: Invalid expression for ISLIB";
+      stop;
+    end;
+    drop &tempcol;
+  end;
+  if prxmatch(&tempcol, trim(&incol)) then &outcol=1;
+  else &outcol=0;
 %end;
 %else %if &rule=LIBDS %then %do;
   /* match libref.dataset */

--- a/base/mp_validatecol.sas
+++ b/base/mp_validatecol.sas
@@ -1,6 +1,6 @@
 /**
   @file
-  @brief Used to validate variables in a dataset
+  @brief Used to validate values in a data step
   @details Useful when sanitising inputs, to ensure that they arrive with a
   certain pattern.
   Usage:
@@ -27,6 +27,7 @@
   @param [in] incol The column to be validated
   @param [in] rule The rule to apply.  Current rules:
     @li ISINT - checks if the variable is an integer
+    @li ISLIB - checks if the value is a valid libref (NOT whether it exists)
     @li ISNUM - checks if the variable is numeric
     @li LIBDS - matches LIBREF.DATASET format
     @li FORMAT - checks if the provided format is syntactically valid
@@ -64,6 +65,19 @@
   if missing(&tempcol) then &outcol=0;
   else &outcol=1;
   drop &tempcol;
+%end;
+%else %if &rule=ISLIB %then %do;
+  if _n_=1 then do;
+    retain &tempcol;
+    &tempcol=prxparse('/^[_a-z]\w{0,7}$/i');
+    if missing(&tempcol) then do;
+      putlog 'ERR' +(-1) "OR: Invalid expression for ISLIB";
+      stop;
+    end;
+    drop &tempcol;
+  end;
+  if prxmatch(&tempcol, trim(&incol)) then &outcol=1;
+  else &outcol=0;
 %end;
 %else %if &rule=LIBDS %then %do;
   /* match libref.dataset */

--- a/tests/base/mp_validatecol.test.sas
+++ b/tests/base/mp_validatecol.test.sas
@@ -130,3 +130,29 @@ run;
   test=EQUALS 6,
   outds=work.test_results
 )
+
+/**
+  * Test 5 - ISLIB
+  */
+data test5;
+  infile datalines4 dsd;
+  input;
+  inf=_infile_;
+  %mp_validatecol(inf,ISLIB,islib)
+  if islib=1;
+datalines4;
+some
+!lib
+%abort
+definite
+2fail
+nineletrs
+.failalso
+_valid
+;;;;
+run;
+%mp_assertdsobs(work.test5,
+  desc=Testing ISLIB,
+  test=EQUALS 3,
+  outds=work.test_results
+)


### PR DESCRIPTION
Usage:

```sas
data test5;
  infile datalines4 dsd;
  input;
  inf=_infile_;
  %mp_validatecol(inf,ISLIB,islib)
  if islib=1;
datalines4;
some
!lib
%abort
definite
2fail
nineletrs
.failalso
_valid
;;;;
run;
%mp_assertdsobs(work.test5,
  desc=Testing ISLIB,
  test=EQUALS 3,
  outds=work.test_results
)
```